### PR TITLE
Adjusting deployment via CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ Execute `deploy.sh`, which essentially does:
     cp firebase.json dist
     firebase deploy --public dist
 
+## Firebase Util
+
+To get a Firebase token for headless CI:
+
+    firebase login:ci
+
+Then create an environment variable named `FIREBASE_TOKEN` with the token value.
+
 ## TODO
 
 ### New features

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val ttDotCom = project
   .enablePlugins(BuildInfoPlugin, LaikaPlugin)
   .settings(
     scalaVersion := s"$scalaVer",
-    version      := "1.1.1",
+    version      := "1.1.3",
 
     // Tell Scala.js that this is an application with a main method
     scalaJSUseMainModuleInitializer := true,


### PR DESCRIPTION
This pull request includes an update to the `README.md` file to add instructions for obtaining a Firebase token for headless CI.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58-R65): Added a section under "Firebase Util" with steps to get a Firebase token for headless CI and instructions to create an environment variable named `FIREBASE_TOKEN` with the token value.