### PR TITLE
Configuring dependabot for Scala and Node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "sbt"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request introduces a configuration file for Dependabot to automate dependency updates for both `sbt` and `npm` packages on a weekly schedule.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R10): Added a new configuration file to set up Dependabot for managing `sbt` and `npm` dependencies with a weekly update schedule.