### PR TITLE
Configuring Scala Steward

### DIFF
--- a/.github/askpass.sh
+++ b/.github/askpass.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "$GITHUB_TOKEN"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/repos.md
+++ b/.github/repos.md
@@ -1,0 +1,1 @@
+https://github.com/talestonini/talestonini.com

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,0 +1,21 @@
+name: Scala Steward
+on:
+  schedule:
+    - cron: "0 0 * * 5"  # runs every Friday at midnight
+  workflow_dispatch:     # allows manual triggering
+
+jobs:
+  scala-steward:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v11
+        with:
+          java-version: '21'
+      - name: Run Scala Steward
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -Lo coursier https://git.io/coursier-cli && chmod +x coursier && ./coursier launch -r https://oss.sonatype.org/content/repositories/public ch.epfl.scala:scala-steward-core_2.13:0.12.0 --main scala_steward_core.StewardCli -- --workspace . --repos-file .github/repos.md --git-ask-pass .github/askpass.sh


### PR DESCRIPTION
This pull request includes several changes to the GitHub Actions workflows and configuration files. The main updates involve adding a new workflow for Scala Steward, modifying the dependabot configuration, and adding a repository URL to the list of repositories.

### GitHub Actions and Configuration Updates:

* [`.github/workflows/scala-steward.yml`](diffhunk://#diff-5f70f29f856428700109959debc5d1f950fa48d279caee7f9f0962a3caa63958R1-R21): Added a new workflow for Scala Steward to run every Friday at midnight and allow manual triggering. This workflow includes steps for checking out the repository, setting up Scala, and running Scala Steward with the necessary environment variables.
* [`.github/askpass.sh`](diffhunk://#diff-96b2c3d39435b237d04962201009f54c361f01357bc0aa91b2e78b58b9c14bdfR1-R2): Added a script to echo the GitHub token, which is used by Scala Steward for authentication.

### Configuration File Modifications:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L3-L6): Removed the Maven package ecosystem configuration, leaving only the npm configuration.
* [`.github/repos.md`](diffhunk://#diff-19d442652e303799271b610ac708feffb6d4f94442b1f657ef1be48364960b40R1): Added a new repository URL (`https://github.com/talestonini/talestonini.com`) to the list of repositories.