### PR TITLE
Scala steward (#182)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 import sbt.internal.util.ManagedLogger
 
-val scalaVer    = "3.7.3" // update prep_public.sh to match this version
+val scalaVer    = "3.7.4" // update prep_public.sh to match this version
 val circeVer    = "0.14.15"
 val http4sVer   = "0.23.33"
 val javaTimeVer = "2.6.0"
@@ -17,7 +17,7 @@ lazy val ttDotCom = project
       "-feature",     // emit warning and location for usages of features that should be imported explicitly
       "-unchecked"    // enable additional warnings where generated code depends on assumptions
     ),
-    version := "1.3.5",
+    version := "1.3.6",
 
     // Tell Scala.js that this is an application with a main method
     scalaJSUseMainModuleInitializer := true,

--- a/prep_public.sh
+++ b/prep_public.sh
@@ -2,7 +2,7 @@
 # Prepares the public directory for both Vite and Firebase.
 
 public_dir=$1
-scala_ver=3.7.3
+scala_ver=3.7.4
 
 rm -rf $public_dir/css
 rm -rf $public_dir/favicom

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -3,6 +3,6 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.16")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.17")
 
 // format: on


### PR DESCRIPTION
* Update sbt to 1.10.4 in scala-steward (#49)



* Update http4s-dom to 0.2.11 in scala-steward (#53)

* Update http4s-dom to 0.2.11 in scala-steward

* Small improvement in versioning

---------




* Update laika-sbt to 1.2.1 in scala-steward (#58)



* Update sbt-buildinfo to 0.13.0 in scala-steward (#56)




* Update sbt-bloop to 2.0.5 in scala-steward (#55)



* Update sbt, scripted-plugin to 1.10.5 in scala-steward (#57)



* Update sbt-buildinfo to 0.13.1 in scala-steward (#60)



* Update http4s-circe, http4s-client to 0.23.30 in scala-steward (#65)



* Update sbt, scripted-plugin to 1.10.6 in scala-steward (#66)



* Update munit to 1.0.3 in scala-steward (#67)



* Update scala3-library_sjs1 to 3.6.2 in scala-steward (#69)



* Minor capitalisation fix in CI/CD

* Update sbt-bloop to 2.0.6 in scala-steward (#72)



* Update sbt, scripted-plugin to 1.10.7 in scala-steward (#76)



* Update waypoint to 9.0.0 in scala-steward (#74)



* Update laminar to 17.2.0 in scala-steward (#73)

* Update laminar to 17.2.0 in scala-steward

* Bump vite from 6.0.3 to 6.0.5 (#75)

* Bump vite from 6.0.3 to 6.0.5

Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 6.0.3 to 6.0.5.
- [Release notes](https://github.com/vitejs/vite/releases)
- [Changelog](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md)
- [Commits](https://github.com/vitejs/vite/commits/v6.0.5/packages/vite)

---
updated-dependencies:
- dependency-name: vite dependency-type: direct:development update-type: version-update:semver-patch ...



* Clean build for testing in CI/CD

---------





* Bump firebase from 11.0.2 to 11.1.0 (#71)

Bumps [firebase](https://github.com/firebase/firebase-js-sdk) from 11.0.2 to 11.1.0.
- [Release notes](https://github.com/firebase/firebase-js-sdk/releases)
- [Changelog](https://github.com/firebase/firebase-js-sdk/blob/main/CHANGELOG.md)
- [Commits](https://github.com/firebase/firebase-js-sdk/compare/firebase@11.0.2...firebase@11.1.0)

---
updated-dependencies:
- dependency-name: firebase dependency-type: direct:production update-type: version-update:semver-minor ...





* Undoing bump of raquo

---------






* Update scalafmt-core to 3.8.5 in scala-steward (#86)

* Update scalafmt-core to 3.8.5 in scala-steward

* Reformat with scalafmt 3.8.5

Executed command: scalafmt --non-interactive

* Add 'Reformat with scalafmt 3.8.5' to .git-blame-ignore-revs

---------



* Update munit to 1.0.4 in scala-steward (#84)



* Update sbt-scalajs, scalajs-library_2.13, ... to 1.18.1 in scala-steward (#83)



* Update upickle to 4.1.0 in scala-steward (#82)



* Update sbt-bloop to 2.0.7 in scala-steward (#85)



* Update laika-sbt to 1.3.1 in scala-steward (#80)



* Reformatting of comments

* Experimenting CI/CD with macos-15-arm64

* Revert "Experimenting CI/CD with macos-15-arm64"

This reverts commit 1b60e0badc673aa6f8992ac58cf22a44ce277b93.

* Fixing CI/CD with ubuntu-24.04

* Bump up patch version

* Revert "Fixing CI/CD with ubuntu-24.04"

This reverts commit 3414b0fa691196c629f88308e5f05cce2e9b2a2c.

* Installing SBT in CI/CD

* Installing SBT in CI/CD (cont...)

* Installing SBT in CI/CD (cont...)

* Installing SBT in CI/CD (cont...)

* Excluding log4s as it fails fullLinkJS

* Back to ubuntu-latest

* Update sbt-bloop to 2.0.13 in scala-steward (#130)



* Update scalajs-dom to 2.8.1 in scala-steward (#128)



* Update circe-core, circe-generic, ... to 0.14.14 in scala-steward (#127)



* Upgdating scalajs

* Update scala-js-env-playwright to 0.1.18 in scala-steward (#93)



* Update scala-xml to 2.4.0 in scala-steward (#126)



* Update upickle to 4.2.1 in scala-steward (#125)



* Update scalafmt-core to 3.8.6 in scala-steward (#97)

* Update scalafmt-core to 3.8.6 in scala-steward

* Reformat with scalafmt 3.8.6

Executed command: scalafmt --non-interactive

* Add 'Reformat with scalafmt 3.8.6' to .git-blame-ignore-revs

---------



* Reformat gen code

* Update munit to 1.1.1 in scala-steward (#123)



* Update sbt, scripted-plugin to 1.10.11 in scala-steward (#112)



* Update ci-cd.yml

* Update scala3-library_sjs1 to 3.6.4 in scala-steward (#108)

* Update scala3-library_sjs1 to 3.6.4 in scala-steward

* Updated Scala ver

---------




* Update ci-cd.yml

* Update laika-sbt to 1.3.2 in scala-steward (#116)



* Update ci-cd.yml

* Update http4s-dom to 0.2.12 in scala-steward (#122)



* Update build.sbt

* Update munit-cats-effect to 2.1.0 in scala-steward (#117)



* Update laminar to 17.2.1 in scala-steward (#114)



* Update sbt, scripted-plugin to 1.11.4 in scala-steward (#134)



* Update scala3-library_sjs1 to 3.7.2 in scala-steward (#133)

* Update scala3-library_sjs1 to 3.7.2 in scala-steward

* Updating prep_public.sh script

---------




* Update sbt, scripted-plugin to 1.11.5 in scala-steward (#139)



* Bring main to scala-steward (#141)

* Bump vite from 6.3.5 to 7.1.2 (#136)

* Bump vite from 6.3.5 to 7.1.2

Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 6.3.5 to 7.1.2.
- [Release notes](https://github.com/vitejs/vite/releases)
- [Changelog](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md)
- [Commits](https://github.com/vitejs/vite/commits/v7.1.2/packages/vite)

---
updated-dependencies:
- dependency-name: vite dependency-version: 7.1.2 dependency-type: direct:development update-type: version-update:semver-major ...



* Removing warning on implicit variables use

---------





* Bump firebase from 11.6.0 to 12.1.0 (#137)

* Bump firebase from 11.6.0 to 12.1.0

Bumps [firebase](https://github.com/firebase/firebase-js-sdk) from 11.6.0 to 12.1.0.
- [Release notes](https://github.com/firebase/firebase-js-sdk/releases)
- [Changelog](https://github.com/firebase/firebase-js-sdk/blob/main/CHANGELOG.md)
- [Commits](https://github.com/firebase/firebase-js-sdk/compare/firebase@11.6.0...firebase@12.1.0)

---
updated-dependencies:
- dependency-name: firebase dependency-version: 12.1.0 dependency-type: direct:production update-type: version-update:semver-major ...



* Bumped patch version

---------





* Update scala-steward.yml

* Revert "Update scala-steward.yml"

This reverts commit 88c36e5b4950b53a5c268f452475e3c79e3b4a8b.

* Scala steward (#140)

* Update sbt to 1.10.4 in scala-steward (#49)



* Update http4s-dom to 0.2.11 in scala-steward (#53)

* Update http4s-dom to 0.2.11 in scala-steward

* Small improvement in versioning

---------




* Update laika-sbt to 1.2.1 in scala-steward (#58)



* Update sbt-buildinfo to 0.13.0 in scala-steward (#56)




* Update sbt-bloop to 2.0.5 in scala-steward (#55)



* Update sbt, scripted-plugin to 1.10.5 in scala-steward (#57)



* Update sbt-buildinfo to 0.13.1 in scala-steward (#60)



* Update http4s-circe, http4s-client to 0.23.30 in scala-steward (#65)



* Update sbt, scripted-plugin to 1.10.6 in scala-steward (#66)



* Update munit to 1.0.3 in scala-steward (#67)



* Update scala3-library_sjs1 to 3.6.2 in scala-steward (#69)



* Minor capitalisation fix in CI/CD

* Update sbt-bloop to 2.0.6 in scala-steward (#72)



* Update sbt, scripted-plugin to 1.10.7 in scala-steward (#76)



* Update waypoint to 9.0.0 in scala-steward (#74)



* Update laminar to 17.2.0 in scala-steward (#73)

* Update laminar to 17.2.0 in scala-steward

* Bump vite from 6.0.3 to 6.0.5 (#75)

* Bump vite from 6.0.3 to 6.0.5

Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 6.0.3 to 6.0.5.
- [Release notes](https://github.com/vitejs/vite/releases)
- [Changelog](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md)
- [Commits](https://github.com/vitejs/vite/commits/v6.0.5/packages/vite)

---
updated-dependencies:
- dependency-name: vite dependency-type: direct:development update-type: version-update:semver-patch ...



* Clean build for testing in CI/CD

---------





* Bump firebase from 11.0.2 to 11.1.0 (#71)

Bumps [firebase](https://github.com/firebase/firebase-js-sdk) from 11.0.2 to 11.1.0.
- [Release notes](https://github.com/firebase/firebase-js-sdk/releases)
- [Changelog](https://github.com/firebase/firebase-js-sdk/blob/main/CHANGELOG.md)
- [Commits](https://github.com/firebase/firebase-js-sdk/compare/firebase@11.0.2...firebase@11.1.0)

---
updated-dependencies:
- dependency-name: firebase dependency-type: direct:production update-type: version-update:semver-minor ...





* Undoing bump of raquo

---------






* Update scalafmt-core to 3.8.5 in scala-steward (#86)

* Update scalafmt-core to 3.8.5 in scala-steward

* Reformat with scalafmt 3.8.5

Executed command: scalafmt --non-interactive

* Add 'Reformat with scalafmt 3.8.5' to .git-blame-ignore-revs

---------



* Update munit to 1.0.4 in scala-steward (#84)



* Update sbt-scalajs, scalajs-library_2.13, ... to 1.18.1 in scala-steward (#83)



* Update upickle to 4.1.0 in scala-steward (#82)



* Update sbt-bloop to 2.0.7 in scala-steward (#85)



* Update laika-sbt to 1.3.1 in scala-steward (#80)



* Reformatting of comments

* Experimenting CI/CD with macos-15-arm64

* Revert "Experimenting CI/CD with macos-15-arm64"

This reverts commit 1b60e0badc673aa6f8992ac58cf22a44ce277b93.

* Fixing CI/CD with ubuntu-24.04

* Bump up patch version

* Revert "Fixing CI/CD with ubuntu-24.04"

This reverts commit 3414b0fa691196c629f88308e5f05cce2e9b2a2c.

* Installing SBT in CI/CD

* Installing SBT in CI/CD (cont...)

* Installing SBT in CI/CD (cont...)

* Installing SBT in CI/CD (cont...)

* Excluding log4s as it fails fullLinkJS

* Back to ubuntu-latest

* Update sbt-bloop to 2.0.13 in scala-steward (#130)



* Update scalajs-dom to 2.8.1 in scala-steward (#128)



* Update circe-core, circe-generic, ... to 0.14.14 in scala-steward (#127)



* Upgdating scalajs

* Update scala-js-env-playwright to 0.1.18 in scala-steward (#93)



* Update scala-xml to 2.4.0 in scala-steward (#126)



* Update upickle to 4.2.1 in scala-steward (#125)



* Update scalafmt-core to 3.8.6 in scala-steward (#97)

* Update scalafmt-core to 3.8.6 in scala-steward

* Reformat with scalafmt 3.8.6

Executed command: scalafmt --non-interactive

* Add 'Reformat with scalafmt 3.8.6' to .git-blame-ignore-revs

---------



* Reformat gen code

* Update munit to 1.1.1 in scala-steward (#123)



* Update sbt, scripted-plugin to 1.10.11 in scala-steward (#112)



* Update ci-cd.yml

* Update scala3-library_sjs1 to 3.6.4 in scala-steward (#108)

* Update scala3-library_sjs1 to 3.6.4 in scala-steward

* Updated Scala ver

---------




* Update ci-cd.yml

* Update laika-sbt to 1.3.2 in scala-steward (#116)



* Update ci-cd.yml

* Update http4s-dom to 0.2.12 in scala-steward (#122)



* Update build.sbt

* Update munit-cats-effect to 2.1.0 in scala-steward (#117)



* Update laminar to 17.2.1 in scala-steward (#114)



* Update sbt, scripted-plugin to 1.11.4 in scala-steward (#134)



* Update scala3-library_sjs1 to 3.7.2 in scala-steward (#133)

* Update scala3-library_sjs1 to 3.7.2 in scala-steward

* Updating prep_public.sh script

---------




* Update sbt, scripted-plugin to 1.11.5 in scala-steward (#139)



---------





---------





* Update upickle to 4.3.0 in scala-steward (#143)



* Update upickle to 4.3.2 in scala-steward (#146)



* Update sbt-scalajs, scalajs-library_2.13, ... to 1.20.1 in scala-steward (#147)



* Update scala3-library_sjs1 to 3.7.3 in scala-steward (#148)



* Update sbt, scripted-plugin to 1.11.6 in scala-steward (#149)



* Update munit to 1.1.2 in scala-steward (#150)



* Update munit to 1.2.0 in scala-steward (#152)



* Update http4s-circe, http4s-client to 0.23.32 in scala-steward (#156)



* Update sbt-bloop to 2.0.15 in scala-steward (#158)



* Update circe-core, circe-generic, ... to 0.14.15 in scala-steward (#159)




* Update sbt-bloop to 2.0.16 in scala-steward (#162)



* Update sbt, scripted-plugin to 1.11.7 in scala-steward (#163)



* Update munit to 1.2.1 in scala-steward (#166)



* Update upickle to 4.4.1 in scala-steward (#175)



* Update http4s-circe, http4s-client to 0.23.33 in scala-steward (#172)



* Update scalafmt-core to 3.10.1 in scala-steward (#173)

* Update scalafmt-core to 3.10.1 in scala-steward

* Reformat with scalafmt 3.10.1

Executed command: scalafmt --non-interactive

* Add 'Reformat with scalafmt 3.10.1' to .git-blame-ignore-revs

---------



* Update scalatest to 3.3.0-alpha.2 in scala-steward (#167)




* Update upickle to 4.4.0 in scala-steward (#170)




* Bring main to scala-steward (#177)

* Scala steward (#164)

* Update sbt to 1.10.4 in scala-steward (#49)



* Update http4s-dom to 0.2.11 in scala-steward (#53)

* Update http4s-dom to 0.2.11 in scala-steward

* Small improvement in versioning

---------




* Update laika-sbt to 1.2.1 in scala-steward (#58)



* Update sbt-buildinfo to 0.13.0 in scala-steward (#56)




* Update sbt-bloop to 2.0.5 in scala-steward (#55)



* Update sbt, scripted-plugin to 1.10.5 in scala-steward (#57)



* Update sbt-buildinfo to 0.13.1 in scala-steward (#60)



* Update http4s-circe, http4s-client to 0.23.30 in scala-steward (#65)



* Update sbt, scripted-plugin to 1.10.6 in scala-steward (#66)



* Update munit to 1.0.3 in scala-steward (#67)



* Update scala3-library_sjs1 to 3.6.2 in scala-steward (#69)



* Minor capitalisation fix in CI/CD

* Update sbt-bloop to 2.0.6 in scala-steward (#72)



* Update sbt, scripted-plugin to 1.10.7 in scala-steward (#76)



* Update waypoint to 9.0.0 in scala-steward (#74)



* Update laminar to 17.2.0 in scala-steward (#73)

* Update laminar to 17.2.0 in scala-steward

* Bump vite from 6.0.3 to 6.0.5 (#75)

* Bump vite from 6.0.3 to 6.0.5

Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 6.0.3 to 6.0.5.
- [Release notes](https://github.com/vitejs/vite/releases)
- [Changelog](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md)
- [Commits](https://github.com/vitejs/vite/commits/v6.0.5/packages/vite)

---
updated-dependencies:
- dependency-name: vite dependency-type: direct:development update-type: version-update:semver-patch ...



* Clean build for testing in CI/CD

---------





* Bump firebase from 11.0.2 to 11.1.0 (#71)

Bumps [firebase](https://github.com/firebase/firebase-js-sdk) from 11.0.2 to 11.1.0.
- [Release notes](https://github.com/firebase/firebase-js-sdk/releases)
- [Changelog](https://github.com/firebase/firebase-js-sdk/blob/main/CHANGELOG.md)
- [Commits](https://github.com/firebase/firebase-js-sdk/compare/firebase@11.0.2...firebase@11.1.0)

---
updated-dependencies:
- dependency-name: firebase dependency-type: direct:production update-type: version-update:semver-minor ...





* Undoing bump of raquo

---------






* Update scalafmt-core to 3.8.5 in scala-steward (#86)

* Update scalafmt-core to 3.8.5 in scala-steward

* Reformat with scalafmt 3.8.5

Executed command: scalafmt --non-interactive

* Add 'Reformat with scalafmt 3.8.5' to .git-blame-ignore-revs

---------



* Update munit to 1.0.4 in scala-steward (#84)



* Update sbt-scalajs, scalajs-library_2.13, ... to 1.18.1 in scala-steward (#83)



* Update upickle to 4.1.0 in scala-steward (#82)



* Update sbt-bloop to 2.0.7 in scala-steward (#85)



* Update laika-sbt to 1.3.1 in scala-steward (#80)



* Reformatting of comments

* Experimenting CI/CD with macos-15-arm64

* Revert "Experimenting CI/CD with macos-15-arm64"

This reverts commit 1b60e0badc673aa6f8992ac58cf22a44ce277b93.

* Fixing CI/CD with ubuntu-24.04

* Bump up patch version

* Revert "Fixing CI/CD with ubuntu-24.04"

This reverts commit 3414b0fa691196c629f88308e5f05cce2e9b2a2c.

* Installing SBT in CI/CD

* Installing SBT in CI/CD (cont...)

* Installing SBT in CI/CD (cont...)

* Installing SBT in CI/CD (cont...)

* Excluding log4s as it fails fullLinkJS

* Back to ubuntu-latest

* Update sbt-bloop to 2.0.13 in scala-steward (#130)



* Update scalajs-dom to 2.8.1 in scala-steward (#128)



* Update circe-core, circe-generic, ... to 0.14.14 in scala-steward (#127)



* Upgdating scalajs

* Update scala-js-env-playwright to 0.1.18 in scala-steward (#93)



* Update scala-xml to 2.4.0 in scala-steward (#126)



* Update upickle to 4.2.1 in scala-steward (#125)



* Update scalafmt-core to 3.8.6 in scala-steward (#97)

* Update scalafmt-core to 3.8.6 in scala-steward

* Reformat with scalafmt 3.8.6

Executed command: scalafmt --non-interactive

* Add 'Reformat with scalafmt 3.8.6' to .git-blame-ignore-revs

---------



* Reformat gen code

* Update munit to 1.1.1 in scala-steward (#123)



* Update sbt, scripted-plugin to 1.10.11 in scala-steward (#112)



* Update ci-cd.yml

* Update scala3-library_sjs1 to 3.6.4 in scala-steward (#108)

* Update scala3-library_sjs1 to 3.6.4 in scala-steward

* Updated Scala ver

---------




* Update ci-cd.yml

* Update laika-sbt to 1.3.2 in scala-steward (#116)



* Update ci-cd.yml

* Update http4s-dom to 0.2.12 in scala-steward (#122)



* Update build.sbt

* Update munit-cats-effect to 2.1.0 in scala-steward (#117)



* Update laminar to 17.2.1 in scala-steward (#114)



* Update sbt, scripted-plugin to 1.11.4 in scala-steward (#134)



* Update scala3-library_sjs1 to 3.7.2 in scala-steward (#133)

* Update scala3-library_sjs1 to 3.7.2 in scala-steward

* Updating prep_public.sh script

---------




* Update sbt, scripted-plugin to 1.11.5 in scala-steward (#139)



* Bring main to scala-steward (#141)

* Bump vite from 6.3.5 to 7.1.2 (#136)

* Bump vite from 6.3.5 to 7.1.2

Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 6.3.5 to 7.1.2.
- [Release notes](https://github.com/vitejs/vite/releases)
- [Changelog](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md)
- [Commits](https://github.com/vitejs/vite/commits/v7.1.2/packages/vite)

---
updated-dependencies:
- dependency-name: vite dependency-version: 7.1.2 dependency-type: direct:development update-type: version-update:semver-major ...



* Removing warning on implicit variables use

---------





* Bump firebase from 11.6.0 to 12.1.0 (#137)

* Bump firebase from 11.6.0 to 12.1.0

Bumps [firebase](https://github.com/firebase/firebase-js-sdk) from 11.6.0 to 12.1.0.
- [Release notes](https://github.com/firebase/firebase-js-sdk/releases)
- [Changelog](https://github.com/firebase/firebase-js-sdk/blob/main/CHANGELOG.md)
- [Commits](https://github.com/firebase/firebase-js-sdk/compare/firebase@11.6.0...firebase@12.1.0)

---
updated-dependencies:
- dependency-name: firebase dependency-version: 12.1.0 dependency-type: direct:production update-type: version-update:semver-major ...



* Bumped patch version

---------





* Update scala-steward.yml

* Revert "Update scala-steward.yml"

This reverts commit 88c36e5b4950b53a5c268f452475e3c79e3b4a8b.

* Scala steward (#140)

* Update sbt to 1.10.4 in scala-steward (#49)



* Update http4s-dom to 0.2.11 in scala-steward (#53)

* Update http4s-dom to 0.2.11 in scala-steward

* Small improvement in versioning

---------




* Update laika-sbt to 1.2.1 in scala-steward (#58)



* Update sbt-buildinfo to 0.13.0 in scala-steward (#56)




* Update sbt-bloop to 2.0.5 in scala-steward (#55)



* Update sbt, scripted-plugin to 1.10.5 in scala-steward (#57)



* Update sbt-buildinfo to 0.13.1 in scala-steward (#60)



* Update http4s-circe, http4s-client to 0.23.30 in scala-steward (#65)



* Update sbt, scripted-plugin to 1.10.6 in scala-steward (#66)



* Update munit to 1.0.3 in scala-steward (#67)



* Update scala3-library_sjs1 to 3.6.2 in scala-steward (#69)



* Minor capitalisation fix in CI/CD

* Update sbt-bloop to 2.0.6 in scala-steward (#72)



* Update sbt, scripted-plugin to 1.10.7 in scala-steward (#76)



* Update waypoint to 9.0.0 in scala-steward (#74)



* Update laminar to 17.2.0 in scala-steward (#73)

* Update laminar to 17.2.0 in scala-steward

* Bump vite from 6.0.3 to 6.0.5 (#75)

* Bump vite from 6.0.3 to 6.0.5

Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 6.0.3 to 6.0.5.
- [Release notes](https://github.com/vitejs/vite/releases)
- [Changelog](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md)
- [Commits](https://github.com/vitejs/vite/commits/v6.0.5/packages/vite)

---
updated-dependencies:
- dependency-name: vite dependency-type: direct:development update-type: version-update:semver-patch ...



* Clean build for testing in CI/CD

---------





* Bump firebase from 11.0.2 to 11.1.0 (#71)

Bumps [firebase](https://github.com/firebase/firebase-js-sdk) from 11.0.2 to 11.1.0.
- [Release notes](https://github.com/firebase/firebase-js-sdk/releases)
- [Changelog](https://github.com/firebase/firebase-js-sdk/blob/main/CHANGELOG.md)
- [Commits](https://github.com/firebase/firebase-js-sdk/compare/firebase@11.0.2...firebase@11.1.0)

---
updated-dependencies:
- dependency-name: firebase dependency-type: direct:production update-type: version-update:semver-minor ...





* Undoing bump of raquo

---------






* Update scalafmt-core to 3.8.5 in scala-steward (#86)

* Update scalafmt-core to 3.8.5 in scala-steward

* Reformat with scalafmt 3.8.5

Executed command: scalafmt --non-interactive

* Add 'Reformat with scalafmt 3.8.5' to .git-blame-ignore-revs

---------



* Update munit to 1.0.4 in scala-steward (#84)



* Update sbt-scalajs, scalajs-library_2.13, ... to 1.18.1 in scala-steward (#83)



* Update upickle to 4.1.0 in scala-steward (#82)



* Update sbt-bloop to 2.0.7 in scala-steward (#85)



* Update laika-sbt to 1.3.1 in scala-steward (#80)



* Reformatting of comments

* Experimenting CI/CD with macos-15-arm64

* Revert "Experimenting CI/CD with macos-15-arm64"

This reverts commit 1b60e0badc673aa6f8992ac58cf22a44ce277b93.

* Fixing CI/CD with ubuntu-24.04

* Bump up patch version

* Revert "Fixing CI/CD with ubuntu-24.04"

This reverts commit 3414b0fa691196c629f88308e5f05cce2e9b2a2c.

* Installing SBT in CI/CD

* Installing SBT in CI/CD (cont...)

* Installing SBT in CI/CD (cont...)

* Installing SBT in CI/CD (cont...)

* Excluding log4s as it fails fullLinkJS

* Back to ubuntu-latest

* Update sbt-bloop to 2.0.13 in scala-steward (#130)



* Update scalajs-dom to 2.8.1 in scala-steward (#128)



* Update circe-core, circe-generic, ... to 0.14.14 in scala-steward (#127)



* Upgdating scalajs

* Update scala-js-env-playwright to 0.1.18 in scala-steward (#93)



* Update scala-xml to 2.4.0 in scala-steward (#126)



* Update upickle to 4.2.1 in scala-steward (#125)



* Update scalafmt-core to 3.8.6 in scala-steward (#97)

* Update scalafmt-core to 3.8.6 in scala-steward

* Reformat with scalafmt 3.8.6

Executed command: scalafmt --non-interactive

* Add 'Reformat with scalafmt 3.8.6' to .git-blame-ignore-revs

---------



* Reformat gen code

* Update munit to 1.1.1 in scala-steward (#123)



* Update sbt, scripted-plugin to 1.10.11 in scala-steward (#112)



* Update ci-cd.yml

* Update scala3-library_sjs1 to 3.6.4 in scala-steward (#108)

* Update scala3-library_sjs1 to 3.6.4 in scala-steward

* Updated Scala ver

---------




* Update ci-cd.yml

* Update laika-sbt to 1.3.2 in scala-steward (#116)



* Update ci-cd.yml

* Update http4s-dom to 0.2.12 in scala-steward (#122)



* Update build.sbt

* Update munit-cats-effect to 2.1.0 in scala-steward (#117)



* Update laminar to 17.2.1 in scala-steward (#114)



* Update sbt, scripted-plugin to 1.11.4 in scala-steward (#134)



* Update scala3-library_sjs1 to 3.7.2 in scala-steward (#133)

* Update scala3-library_sjs1 to 3.7.2 in scala-steward

* Updating prep_public.sh script

---------




* Update sbt, scripted-plugin to 1.11.5 in scala-steward (#139)



---------





---------





* Update upickle to 4.3.0 in scala-steward (#143)



* Update upickle to 4.3.2 in scala-steward (#146)



* Update sbt-scalajs, scalajs-library_2.13, ... to 1.20.1 in scala-steward (#147)



* Update scala3-library_sjs1 to 3.7.3 in scala-steward (#148)



* Update sbt, scripted-plugin to 1.11.6 in scala-steward (#149)



* Update munit to 1.1.2 in scala-steward (#150)



* Update munit to 1.2.0 in scala-steward (#152)



* Update http4s-circe, http4s-client to 0.23.32 in scala-steward (#156)



* Update sbt-bloop to 2.0.15 in scala-steward (#158)



* Update circe-core, circe-generic, ... to 0.14.15 in scala-steward (#159)




* Update sbt-bloop to 2.0.16 in scala-steward (#162)



* Update sbt, scripted-plugin to 1.11.7 in scala-steward (#163)



---------





* Scala steward (#176)

* Update sbt to 1.10.4 in scala-steward (#49)



* Update http4s-dom to 0.2.11 in scala-steward (#53)

* Update http4s-dom to 0.2.11 in scala-steward

* Small improvement in versioning

---------




* Update laika-sbt to 1.2.1 in scala-steward (#58)



* Update sbt-buildinfo to 0.13.0 in scala-steward (#56)




* Update sbt-bloop to 2.0.5 in scala-steward (#55)



* Update sbt, scripted-plugin to 1.10.5 in scala-steward (#57)



* Update sbt-buildinfo to 0.13.1 in scala-steward (#60)



* Update http4s-circe, http4s-client to 0.23.30 in scala-steward (#65)



* Update sbt, scripted-plugin to 1.10.6 in scala-steward (#66)



* Update munit to 1.0.3 in scala-steward (#67)



* Update scala3-library_sjs1 to 3.6.2 in scala-steward (#69)



* Minor capitalisation fix in CI/CD

* Update sbt-bloop to 2.0.6 in scala-steward (#72)



* Update sbt, scripted-plugin to 1.10.7 in scala-steward (#76)



* Update waypoint to 9.0.0 in scala-steward (#74)



* Update laminar to 17.2.0 in scala-steward (#73)

* Update laminar to 17.2.0 in scala-steward

* Bump vite from 6.0.3 to 6.0.5 (#75)

* Bump vite from 6.0.3 to 6.0.5

Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 6.0.3 to 6.0.5.
- [Release notes](https://github.com/vitejs/vite/releases)
- [Changelog](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md)
- [Commits](https://github.com/vitejs/vite/commits/v6.0.5/packages/vite)

---
updated-dependencies:
- dependency-name: vite dependency-type: direct:development update-type: version-update:semver-patch ...



* Clean build for testing in CI/CD

---------





* Bump firebase from 11.0.2 to 11.1.0 (#71)

Bumps [firebase](https://github.com/firebase/firebase-js-sdk) from 11.0.2 to 11.1.0.
- [Release notes](https://github.com/firebase/firebase-js-sdk/releases)
- [Changelog](https://github.com/firebase/firebase-js-sdk/blob/main/CHANGELOG.md)
- [Commits](https://github.com/firebase/firebase-js-sdk/compare/firebase@11.0.2...firebase@11.1.0)

---
updated-dependencies:
- dependency-name: firebase dependency-type: direct:production update-type: version-update:semver-minor ...





* Undoing bump of raquo

---------






* Update scalafmt-core to 3.8.5 in scala-steward (#86)

* Update scalafmt-core to 3.8.5 in scala-steward

* Reformat with scalafmt 3.8.5

Executed command: scalafmt --non-interactive

* Add 'Reformat with scalafmt 3.8.5' to .git-blame-ignore-revs

---------



* Update munit to 1.0.4 in scala-steward (#84)



* Update sbt-scalajs, scalajs-library_2.13, ... to 1.18.1 in scala-steward (#83)



* Update upickle to 4.1.0 in scala-steward (#82)



* Update sbt-bloop to 2.0.7 in scala-steward (#85)



* Update laika-sbt to 1.3.1 in scala-steward (#80)



* Reformatting of comments

* Experimenting CI/CD with macos-15-arm64

* Revert "Experimenting CI/CD with macos-15-arm64"

This reverts commit 1b60e0badc673aa6f8992ac58cf22a44ce277b93.

* Fixing CI/CD with ubuntu-24.04

* Bump up patch version

* Revert "Fixing CI/CD with ubuntu-24.04"

This reverts commit 3414b0fa691196c629f88308e5f05cce2e9b2a2c.

* Installing SBT in CI/CD

* Installing SBT in CI/CD (cont...)

* Installing SBT in CI/CD (cont...)

* Installing SBT in CI/CD (cont...)

* Excluding log4s as it fails fullLinkJS

* Back to ubuntu-latest

* Update sbt-bloop to 2.0.13 in scala-steward (#130)



* Update scalajs-dom to 2.8.1 in scala-steward (#128)



* Update circe-core, circe-generic, ... to 0.14.14 in scala-steward (#127)



* Upgdating scalajs

* Update scala-js-env-playwright to 0.1.18 in scala-steward (#93)



* Update scala-xml to 2.4.0 in scala-steward (#126)



* Update upickle to 4.2.1 in scala-steward (#125)



* Update scalafmt-core to 3.8.6 in scala-steward (#97)

* Update scalafmt-core to 3.8.6 in scala-steward

* Reformat with scalafmt 3.8.6

Executed command: scalafmt --non-interactive

* Add 'Reformat with scalafmt 3.8.6' to .git-blame-ignore-revs

---------



* Reformat gen code

* Update munit to 1.1.1 in scala-steward (#123)



* Update sbt, scripted-plugin to 1.10.11 in scala-steward (#112)



* Update ci-cd.yml

* Update scala3-library_sjs1 to 3.6.4 in scala-steward (#108)

* Update scala3-library_sjs1 to 3.6.4 in scala-steward

* Updated Scala ver

---------




* Update ci-cd.yml

* Update laika-sbt to 1.3.2 in scala-steward (#116)



* Update ci-cd.yml

* Update http4s-dom to 0.2.12 in scala-steward (#122)



* Update build.sbt

* Update munit-cats-effect to 2.1.0 in scala-steward (#117)



* Update laminar to 17.2.1 in scala-steward (#114)



* Update sbt, scripted-plugin to 1.11.4 in scala-steward (#134)



* Update scala3-library_sjs1 to 3.7.2 in scala-steward (#133)

* Update scala3-library_sjs1 to 3.7.2 in scala-steward

* Updating prep_public.sh script

---------




* Update sbt, scripted-plugin to 1.11.5 in scala-steward (#139)



* Bring main to scala-steward (#141)

* Bump vite from 6.3.5 to 7.1.2 (#136)

* Bump vite from 6.3.5 to 7.1.2

Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 6.3.5 to 7.1.2.
- [Release notes](https://github.com/vitejs/vite/releases)
- [Changelog](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md)
- [Commits](https://github.com/vitejs/vite/commits/v7.1.2/packages/vite)

---
updated-dependencies:
- dependency-name: vite dependency-version: 7.1.2 dependency-type: direct:development update-type: version-update:semver-major ...



* Removing warning on implicit variables use

---------





* Bump firebase from 11.6.0 to 12.1.0 (#137)

* Bump firebase from 11.6.0 to 12.1.0

Bumps [firebase](https://github.com/firebase/firebase-js-sdk) from 11.6.0 to 12.1.0.
- [Release notes](https://github.com/firebase/firebase-js-sdk/releases)
- [Changelog](https://github.com/firebase/firebase-js-sdk/blob/main/CHANGELOG.md)
- [Commits](https://github.com/firebase/firebase-js-sdk/compare/firebase@11.6.0...firebase@12.1.0)

---
updated-dependencies:
- dependency-name: firebase dependency-version: 12.1.0 dependency-type: direct:production update-type: version-update:semver-major ...



* Bumped patch version

---------





* Update scala-steward.yml

* Revert "Update scala-steward.yml"

This reverts commit 88c36e5b4950b53a5c268f452475e3c79e3b4a8b.

* Scala steward (#140)

* Update sbt to 1.10.4 in scala-steward (#49)



* Update http4s-dom to 0.2.11 in scala-steward (#53)

* Update http4s-dom to 0.2.11 in scala-steward

* Small improvement in versioning

---------




* Update laika-sbt to 1.2.1 in scala-steward (#58)



* Update sbt-buildinfo to 0.13.0 in scala-steward (#56)




* Update sbt-bloop to 2.0.5 in scala-steward (#55)



* Update sbt, scripted-plugin to 1.10.5 in scala-steward (#57)



* Update sbt-buildinfo to 0.13.1 in scala-steward (#60)



* Update http4s-circe, http4s-client to 0.23.30 in scala-steward (#65)



* Update sbt, scripted-plugin to 1.10.6 in scala-steward (#66)



* Update munit to 1.0.3 in scala-steward (#67)



* Update scala3-library_sjs1 to 3.6.2 in scala-steward (#69)



* Minor capitalisation fix in CI/CD

* Update sbt-bloop to 2.0.6 in scala-steward (#72)



* Update sbt, scripted-plugin to 1.10.7 in scala-steward (#76)



* Update waypoint to 9.0.0 in scala-steward (#74)



* Update laminar to 17.2.0 in scala-steward (#73)

* Update laminar to 17.2.0 in scala-steward

* Bump vite from 6.0.3 to 6.0.5 (#75)

* Bump vite from 6.0.3 to 6.0.5

Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 6.0.3 to 6.0.5.
- [Release notes](https://github.com/vitejs/vite/releases)
- [Changelog](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md)
- [Commits](https://github.com/vitejs/vite/commits/v6.0.5/packages/vite)

---
updated-dependencies:
- dependency-name: vite dependency-type: direct:development update-type: version-update:semver-patch ...



* Clean build for testing in CI/CD

---------





* Bump firebase from 11.0.2 to 11.1.0 (#71)

Bumps [firebase](https://github.com/firebase/firebase-js-sdk) from 11.0.2 to 11.1.0.
- [Release notes](https://github.com/firebase/firebase-js-sdk/releases)
- [Changelog](https://github.com/firebase/firebase-js-sdk/blob/main/CHANGELOG.md)
- [Commits](https://github.com/firebase/firebase-js-sdk/compare/firebase@11.0.2...firebase@11.1.0)

---
updated-dependencies:
- dependency-name: firebase dependency-type: direct:production update-type: version-update:semver-minor ...





* Undoing bump of raquo

---------






* Update scalafmt-core to 3.8.5 in scala-steward (#86)

* Update scalafmt-core to 3.8.5 in scala-steward

* Reformat with scalafmt 3.8.5

Executed command: scalafmt --non-interactive

* Add 'Reformat with scalafmt 3.8.5' to .git-blame-ignore-revs

---------



* Update munit to 1.0.4 in scala-steward (#84)



* Update sbt-scalajs, scalajs-library_2.13, ... to 1.18.1 in scala-steward (#83)



* Update upickle to 4.1.0 in scala-steward (#82)



* Update sbt-bloop to 2.0.7 in scala-steward (#85)



* Update laika-sbt to 1.3.1 in scala-steward (#80)



* Reformatting of comments

* Experimenting CI/CD with macos-15-arm64

* Revert "Experimenting CI/CD with macos-15-arm64"

This reverts commit 1b60e0badc673aa6f8992ac58cf22a44ce277b93.

* Fixing CI/CD with ubuntu-24.04

* Bump up patch version

* Revert "Fixing CI/CD with ubuntu-24.04"

This reverts commit 3414b0fa691196c629f88308e5f05cce2e9b2a2c.

* Installing SBT in CI/CD

* Installing SBT in CI/CD (cont...)

* Installing SBT in CI/CD (cont...)

* Installing SBT in CI/CD (cont...)

* Excluding log4s as it fails fullLinkJS

* Back to ubuntu-latest

* Update sbt-bloop to 2.0.13 in scala-steward (#130)



* Update scalajs-dom to 2.8.1 in scala-steward (#128)



* Update circe-core, circe-generic, ... to 0.14.14 in scala-steward…